### PR TITLE
修复腾讯云开机失败，改进重试逻辑

### DIFF
--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -188,7 +188,7 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 			if terminateErr != nil && terminateErr.(*errors.TencentCloudSDKError).Code != "InvalidInstanceId.NotFound" {
 				// undefined behavior, just halt
 				// halt use put to store error in state, it cannot append
-				return Halt(state, terminateErr, fmt.Sprintf("Failed to terminate instance(%s), may need to delete it manually", id))
+				return Halt(state, terminateErr, fmt.Sprintf("Failed to terminate instance(%s), may need to delete it manually", *id))
 			}
 		}
 	}


### PR DESCRIPTION
腾讯云开机时返回instanceid后还需要等待实例状态为running才可认为开机成功。
如果资源不足或者配置有错误如ip冲突会造成状态为LAUNCH_FAILED。通过现有的wait函数可以等待实例状态变为running。
如果实例id成功返回但是wait失败则尝试删除以防止资源泄露。
此时，若是开机状态LAUNCH_FAILED会预到Code=InvalidInstanceId.NotFound报错，可安全无视此报错，跳过尝试下一个subnet继续尝试开机即可。