### PR TITLE
修复开机失败没有生成id时依旧尝试关机的错误

### DIFF
--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
 	vpc "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312"
-	"log"
-	"os"
-	"strings"
 )
 
 // 移除了zoneid，由subnet step生成的subnet信息提供

--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -178,7 +178,7 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 			break
 		}
 		// InstanceIdSet不为空，代表已经创建了instance，但是开机不成功，此时需要删除instance
-		if instanceIds != nil {
+		if len(instanceIds) > 0 {
 			// 尝试删除已有的instanceId，避免资源泄露
 			terminateReq := cvm.NewTerminateInstancesRequest()
 			terminateReq.InstanceIds = instanceIds


### PR DESCRIPTION
CreateCvmInstance在开机失败如库存不足的时候不会返回带有id的列表，而是会返回nil。而把nil当成参数发送给关机api会造成api返回错误，无法进行下一次开机重试。