### PR TITLE
生成镜像前先关机

### DIFF
--- a/builder/tencentcloud/cvm/step_detach_temp_key_pair.go
+++ b/builder/tencentcloud/cvm/step_detach_temp_key_pair.go
@@ -24,13 +24,31 @@ func (s *stepDetachTempKeyPair) Run(ctx context.Context, state multistep.StateBa
 	keyId := state.Get("temporary_key_pair_id").(string)
 	instance := state.Get("instance").(*cvm.Instance)
 
+	// 生成镜像前先关机，避免创建镜像过程中发生重启导致服务意外启动
+	Say(state, *instance.InstanceName, "Trying to stop instance")
+
+	stopReq := cvm.NewStopInstancesRequest()
+	stopReq.InstanceIds = []*string{instance.InstanceId}
+	err := Retry(ctx, func(ctx context.Context) error {
+		_, e := client.StopInstances(stopReq)
+		return e
+	})
+	if err != nil {
+		return Halt(state, err, "Failed to stop instance")
+	}
+	Message(state, "Waiting for instance stop", "")
+	err = WaitForInstance(ctx, client, *instance.InstanceId, "STOPPED", 1800)
+	if err != nil {
+		return Halt(state, err, "Failed to wait for instance to be stopped")
+	}
+
 	Say(state, keyId, "Trying to detach keypair")
 
 	req := cvm.NewDisassociateInstancesKeyPairsRequest()
 	req.KeyIds = []*string{&keyId}
 	req.InstanceIds = []*string{instance.InstanceId}
-	req.ForceStop = common.BoolPtr(true)
-	err := Retry(ctx, func(ctx context.Context) error {
+	req.ForceStop = common.BoolPtr(false)
+	err = Retry(ctx, func(ctx context.Context) error {
 		_, e := client.DisassociateInstancesKeyPairs(req)
 		return e
 	})
@@ -39,7 +57,7 @@ func (s *stepDetachTempKeyPair) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	Message(state, "Waiting for keypair detached", "")
-	err = WaitForInstance(ctx, client, *instance.InstanceId, "RUNNING", 1800)
+	err = WaitForInstance(ctx, client, *instance.InstanceId, "STOPPED", 1800)
 	if err != nil {
 		return Halt(state, err, "Failed to wait for keypair detached")
 	}


### PR DESCRIPTION
# 背景
腾讯云在创建系统镜像的时候会进行软关机后开机的操作，导致部分设置为开机自启的服务意外启动产生了报错日志。
相关文档 https://cloud.tencent.com/document/api/213/16726

![image](https://github.com/shinnytech/packer-plugin-tencentcloud/assets/116700000/2872a048-84ed-4227-8a20-ffb8753ef6c2)

# 方案
生成镜像前先关机，避免创建镜像过程中发生重启导致服务意外启动